### PR TITLE
Adds local docker test runner

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,9 @@ on:
     tags-ignore:
       - v.*
   pull_request:
+    types:
+      - opened
+      - reopened
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -17,15 +20,17 @@ permissions:
   contents: read
 
 jobs:
-  tests:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [macos-latest, ubuntu-latest]
+  tests on macos:
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: fish-actions/install-fish@v1
       - run: make test -C "$GITHUB_WORKSPACE"
+
+  tests on linux:
+    runs-on: ubuntu-latest
+    steps:
+      - run: make dockertest -C "$GITHUB_WORKSPACE"
 
   syntax-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,14 +20,14 @@ permissions:
   contents: read
 
 jobs:
-  tests on macos:
+  test-macos:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: fish-actions/install-fish@v1
       - run: make test -C "$GITHUB_WORKSPACE"
 
-  tests on linux:
+  test-linux:
     runs-on: ubuntu-latest
     steps:
       - run: make dockertest -C "$GITHUB_WORKSPACE"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,6 +30,7 @@ jobs:
   test-linux:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - run: make dockertest -C "$GITHUB_WORKSPACE"
 
   syntax-check:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: fish-actions/install-fish@v1
       - run: make dockertest -C "$GITHUB_WORKSPACE"
 
   syntax-check:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: fish-actions/install-fish@v1
-      - run: make dockertest -C "$GITHUB_WORKSPACE"
+      - run: make test -C "$GITHUB_WORKSPACE"
 
   syntax-check:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -12,20 +12,34 @@ lint:
 	@for file in **.fish; fish --no-execute $$file; end
 
 .PHONY: install
-install:
-	@type -q fisher || begin; curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher; end
+install: fisher
 	@fisher install . >/dev/null
 
-littlecheck.py:
-	@curl -sL https://raw.githubusercontent.com/ridiculousfish/littlecheck/HEAD/littlecheck/littlecheck.py -o littlecheck.py
+.PHONY: fisher
+fisher:
+	@type -q fisher || begin; curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher; end
+
+.PHONY: testsetup
+testsetup: fisher
+	@type -q mock || fisher install IlanCosman/clownfish
+	@test -e littlecheck.py || curl -sL https://raw.githubusercontent.com/ridiculousfish/littlecheck/HEAD/littlecheck/littlecheck.py -o littlecheck.py
+	@test -e $$__fish_config_dir/conf.d/tide_test_setup.fish || cp tests/utils/tide_test_setup.fish $$__fish_config_dir/conf.d/tide_test_setup.fish
+	@test -e $$__fish_config_dir/functions/_tide_decolor.fish || cp tests/utils/_tide_decolor.fish $$__fish_config_dir/functions/_tide_decolor.fish
 
 .PHONY: test
-test: install littlecheck.py
-	@type -q mock || fisher install IlanCosman/clownfish
-	@fish tests/test_setup.fish
+test: testsetup install
 	@_tide_remove_unusable_items
 	@_tide_cache_variables; python3 littlecheck.py --progress tests/**.test.fish
 
+.PHONY: dockertest
+dockertest:
+	@source tests/utils/docker.fish && docker_run make test
+
+.PHONY: dockerdebug
+dockerdebug:
+	@source tests/utils/docker.fish && docker_run --debug
+
 .PHONY: clean
 clean:
-	@rm littlecheck.py
+	@not type -q docker || begin; source tests/utils/docker.fish && docker_clean; end
+	@not test -e littlecheck.py || rm littlecheck.py

--- a/tests/test_setup.fish
+++ b/tests/test_setup.fish
@@ -1,8 +1,0 @@
-function _tide_decolor
-    string replace --all -r '\e(\[[\d;]*|\(B\e\[)m(\co)?' '' "$argv"
-end
-funcsave _tide_decolor
-
-echo "\
-set TERM xterm-256color
-set -g _tide_side right" >$__fish_config_dir/conf.d/tide_test_setup.fish

--- a/tests/utils/Dockerfile
+++ b/tests/utils/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:sid-slim
 
+# don't pin packages, despite what DL3008 says
+# hadolint ignore=DL3008
 RUN apt-get update \
     && apt-get install -y -qq --no-install-recommends fish make curl git \
     && apt-get clean \
@@ -7,7 +9,7 @@ RUN apt-get update \
     && groupadd --gid 1000 tide \
     && useradd --create-home --gid 1000 --shell /usr/bin/fish --uid 1000 tide \
     && mkdir --parents "/home/tide/{src/tide,.config/fish/conf.d}" \
-    && chown --recursive tide:tide "/home/tide" # hadolint ignore=DL3008
+    && chown --recursive tide:tide "/home/tide"
 
 COPY --link --chown=1000:1000 . /home/tide/src/tide
 

--- a/tests/utils/Dockerfile
+++ b/tests/utils/Dockerfile
@@ -1,11 +1,9 @@
 FROM debian:sid-slim
 
 RUN apt-get update \
-    && apt-get install -y -qq fish make sudo curl git \
-    && echo "%tide ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/tide" \
-    && chmod 0440 "/etc/sudoers.d/tide" \
+    && apt-get install -y -qq fish make curl git \
     && groupadd --gid 1000 tide \
-    && useradd --create-home --gid 1000 --shell /usr/bin/fish --system --uid 1000 tide \
+    && useradd --create-home --gid 1000 --shell /usr/bin/fish --uid 1000 tide \
     && mkdir --parents "/home/tide/{src/tide,.config/fish/conf.d}" \
     && chown --recursive tide:tide "/home/tide"
 

--- a/tests/utils/Dockerfile
+++ b/tests/utils/Dockerfile
@@ -1,7 +1,9 @@
 FROM debian:sid-slim
 
 RUN apt-get update \
-    && apt-get install -y -qq fish make curl git \
+    && apt-get install -y -qq --no-install-recommends fish make curl git \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
     && groupadd --gid 1000 tide \
     && useradd --create-home --gid 1000 --shell /usr/bin/fish --uid 1000 tide \
     && mkdir --parents "/home/tide/{src/tide,.config/fish/conf.d}" \

--- a/tests/utils/Dockerfile
+++ b/tests/utils/Dockerfile
@@ -1,0 +1,17 @@
+FROM debian:sid-slim
+
+RUN apt-get update \
+    && apt-get install -y -qq fish make sudo curl git \
+    && echo "%tide ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/tide" \
+    && chmod 0440 "/etc/sudoers.d/tide" \
+    && groupadd --gid 1000 tide \
+    && useradd --create-home --gid 1000 --shell /usr/bin/fish --system --uid 1000 tide \
+    && mkdir --parents "/home/tide/{src/tide,.config/fish/conf.d}" \
+    && chown --recursive tide:tide "/home/tide"
+
+COPY --link --chown=1000:1000 . /home/tide/src/tide
+
+WORKDIR /home/tide/src/tide
+USER tide
+ENTRYPOINT ["/usr/bin/fish", "--login"]
+RUN make testsetup

--- a/tests/utils/Dockerfile
+++ b/tests/utils/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
     && groupadd --gid 1000 tide \
     && useradd --create-home --gid 1000 --shell /usr/bin/fish --uid 1000 tide \
     && mkdir --parents "/home/tide/{src/tide,.config/fish/conf.d}" \
-    && chown --recursive tide:tide "/home/tide"
+    && chown --recursive tide:tide "/home/tide" # hadolint ignore=DL3008
 
 COPY --link --chown=1000:1000 . /home/tide/src/tide
 

--- a/tests/utils/Dockerfile
+++ b/tests/utils/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update \
 
 COPY --link --chown=1000:1000 . /home/tide/src/tide
 
+HEALTHCHECK NONE
 WORKDIR /home/tide/src/tide
 USER tide
 ENTRYPOINT ["/usr/bin/fish", "--login"]

--- a/tests/utils/_tide_decolor.fish
+++ b/tests/utils/_tide_decolor.fish
@@ -1,0 +1,3 @@
+function _tide_decolor
+    string replace --all -r '\e(\[[\d;]*|\(B\e\[)m(\co)?' '' "$argv"
+end

--- a/tests/utils/docker.fish
+++ b/tests/utils/docker.fish
@@ -1,0 +1,45 @@
+function docker_build
+    argparse v/verbose -- $argv
+    or return 1
+
+    test -n "$_flag_verbose"
+    or set quiet --quiet
+
+    set repo (string escape --no-quoted (git rev-parse --show-toplevel))
+    docker build $quiet --label=tide=test --tag=tide-test:latest --file="$repo/tests/utils/Dockerfile" "$repo"
+end
+
+function docker_run
+    argparse b/bind d/debug k/keep r/rebuild -- $argv
+    or return 1
+
+    set -a flags --label=tide=test --tty
+
+    test -n "$_flag_bind"
+    and set -a flags --volume=(git rev-parse --show-toplevel):/home/tide/src/tide
+
+    if test -n "$_flag_debug"
+        set -a flags --interactive
+        set -a build_flags --verbose
+    else
+        set cmd -c "$argv"
+    end
+
+    test -n "$_flag_keep"
+    or set -a flags --rm
+
+    test -n "$_flag_rebuild" || test -z "$_flag_bind" || not docker_has_image
+    and docker_build $build_flags
+
+    docker run $flags tide-test:latest $cmd
+end
+
+function docker_clean
+    docker container prune --force --filter=label=tide=test
+    docker_has_image && docker image rm tide-test:latest
+    docker image prune --force --filter=label=tide=test
+end
+
+function docker_has_image
+    docker image list --quiet tide-test:latest | grep --quiet '[a-z0-9]'
+end

--- a/tests/utils/tide_test_setup.fish
+++ b/tests/utils/tide_test_setup.fish
@@ -1,0 +1,4 @@
+# dest: .config/fish/conf.d/tide_test_setup.fish
+# for testing
+set -g _tide_side right
+set -gx TERM xterm-256color


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

#### Description

- Adds `tests/utils/Dockerfile`
  - Based on `debian:sid-slim`, installs latest fish/dependencies, creates `tide` user, copies repo into `/home/tide/src/tide` runs `make testsetup` so it's ready to run tests immediately
- Adds `tests/utils/docker.fish`
  - Contains functions for building, running, debugging, and cleaning up the container
    - Labels all built images & containers with `tide=test`
    - ONLY cleans up containers & images with the above label
  - Optionally, can bind mount the repo in for a blazing fast dev/test cycle
- Rearranges make targets & `tests/test_setup.fish`
  - Adds `dockertest` and `dockerdebug` for running tests in docker and debugging in docker
  - Splits fisher install out into its own target, allowing `install` and `fisher` to be used independently of testing
  - Adds `testsetup` target for fully building the test environment
    - Installs clownfish (moved from `test` target)
    - Downloads `littlecheck.py` if it doesn't exist already (moved from `littlecheck.py` target
    - Copies tide_test_setup.fish to `$__fish_config_dir/conf.d` if it doesn't exist already (moved from `tests/test_setup.fish`)
    - Copies `_tide_decolor.fish` to `$__fish_config_dir/functions` if it doesn't exist already (moved from `tests/test_setup.fish`)
  - Adds to `clean` target
    - Some conditional checks to `clean` target so it runs idempotently without error, no matter the existing state
    - Conditional call to `docker_clean`

<!-- Describe your changes. -->

<!-- This following sections apply only to large PRs, you may disregard them for small ones. -->

#### Motivation and Context

I wanted the ability to run tests without modifying my local tide config & without pushing to a PR. This adds facilities for local docker test running and rearranges some things to accomodate.

<!-- Why is this change required? What problem does it solve? -->

Closes # <!--- Please link to an open issue. -->

#### Screenshots (if appropriate)

#### How Has This Been Tested

I've been running `make dockertest`, `make dockerdebug`, and all of the functions/supported options in `tests/utils/docker.fish` while working on this feature. My host machine is macOS, running fish 4.0.1, using Docker Desktop.

<!-- Please describe how you tested your changes. -->
<!-- If you have not tested your changes on both OSes, someone else can help you out. -->

- [x] I have tested using **Linux** (sorta, the contianer is linux)
- [x] I have tested using **MacOS** (sorta, my host machine is macOS)

#### Checklist

<!-- Go over the following points and put an x in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask! -->

- [x] I am ready to update the wiki accordingly.
- [x] I have updated the tests accordingly.
